### PR TITLE
replaced deleteOnExit by delete at the end of the copy method

### DIFF
--- a/src/odml/core/Section.java
+++ b/src/odml/core/Section.java
@@ -1581,7 +1581,6 @@ public class Section extends Object implements Serializable, TreeNode {
     */
    public Section copy() throws IOException, ClassNotFoundException {
       File tempFile = File.createTempFile("section", ".ser");
-      tempFile.deleteOnExit();
       ObjectOutputStream objOut = new ObjectOutputStream(new BufferedOutputStream(
             new FileOutputStream(tempFile)));
       objOut.writeObject(this);
@@ -1592,6 +1591,7 @@ public class Section extends Object implements Serializable, TreeNode {
       Section copy = (Section) objIn.readObject();
       objIn.close();
       copy.setParent(null);
+      tempFile.delete();
       return copy;
    }
 


### PR DESCRIPTION
The copy method for copying sections used a tmp file deleted by the deleteOnExit method. This method has been replaced by the delete method at the end of the copy method.

Reasons are:
The deleteOnExit method is called when JVM terminates by the end of the main method -> There is no reason to keep the tmp files all the time the application is running. Once the copy method is at the end the tmp file can be deleted without problems.

The DeleteOnExit method is never called on server applications. They usually don't terminate for long time and repeated calling the copy method creates an increasing set of tmp files what are never deleted.


